### PR TITLE
Trivial fix for name of README file in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,5 @@ setup(
     url = 'https://launchpad.net/ijson',
     license = 'LICENSE.txt',
     description = 'A Python wrapper to YAJL providing standard iterator interface to streaming JSON parsing',
-    long_description = open('README.txt').read(),
+    long_description = open('README.rst').read(),
 )


### PR DESCRIPTION
setup.py was looking for README.txt
I changed it to look for README.rst
