### PR TITLE
Added multiple value support to yajl2 backend

### DIFF
--- a/ijson/backends/yajl2.py
+++ b/ijson/backends/yajl2.py
@@ -60,10 +60,13 @@ YAJL_CANCELLED = 1
 YAJL_INSUFFICIENT_DATA = 2
 YAJL_ERROR = 3
 
+# constants defined in yajl_parse.h
 YAJL_ALLOW_COMMENTS = 1
+YAJL_MULTIPLE_VALUES = 8
 
 
-def basic_parse(f, allow_comments=False, buf_size=64 * 1024):
+def basic_parse(f, allow_comments=False, buf_size=64 * 1024,
+                multiple_values=False):
     '''
     Iterator yielding unprefixed events.
 
@@ -72,6 +75,7 @@ def basic_parse(f, allow_comments=False, buf_size=64 * 1024):
     - f: a readable file-like object with JSON input
     - allow_comments: tells parser to allow comments in JSON input
     - buf_size: a size of an input buffer
+    - multiple_values: allows the parser to parse multiple JSON objects
     '''
     events = []
 
@@ -85,6 +89,8 @@ def basic_parse(f, allow_comments=False, buf_size=64 * 1024):
     handle = yajl.yajl_alloc(byref(callbacks), None, None)
     if allow_comments:
         yajl.yajl_config(handle, YAJL_ALLOW_COMMENTS, 1)
+    if multiple_values:
+        yajl.yajl_config(handle, YAJL_MULTIPLE_VALUES, 1)
     try:
         while True:
             buffer = f.read(buf_size)


### PR DESCRIPTION
Some APIs seem to use a stream-like approach where JSON objects are just concatenated onto one another. Yajl supports this with a [multiple_values](https://github.com/lloyd/yajl/blob/master/src/api/yajl_parse.h#L151) flag but this was not exposed by ijson so I added it.

There are a couple things to think about here:
- Should this be added to the other backends or should it only be for yajl2?
- Should the remaining flags also be exposed?
- Is an optional parameter for each flag the best approach to exposing these flags?

No decision needs to be made immediately on these. As for this pull request, I just stuck to the same pattern that I saw in the code for allowing comments.
