### PR TITLE
Handle very old YAJL without yajl_version method

### DIFF
--- a/ijson/backends/__init__.py
+++ b/ijson/backends/__init__.py
@@ -8,7 +8,10 @@ def find_yajl(required):
     if so_name is None:
         raise YAJLImportError('YAJL shared object not found.')
     yajl = cdll.LoadLibrary(so_name)
-    major, rest = divmod(yajl.yajl_version(), 10000)
+    if hasattr(yajl, 'yajl_version'):
+        major, rest = divmod(yajl.yajl_version(), 10000)
+    else:
+        major, rest = 0, 0
     minor, micro = divmod(rest, 100)
     if major != required:
         raise YAJLImportError('YAJL version %s.x required, found %s.%s.%s' % (required, major, minor, micro))


### PR DESCRIPTION
old yajl versions don't have the yajl_version method and produce an AttributeError when importing ijson.

See the following backtrace:

ERROR: Failure: AttributeError (/usr/lib64/libyajl.so.1: undefined symbol: yajl_version)

   Traceback (most recent call last):
    .venv/contentpublisher-3.0.0-Linux/lib/python2.6/site-packages/nose/loader.py line 413 in loadTestsFromName
      addr.filename, addr.module)
    .venv/contentpublisher-3.0.0-Linux/lib/python2.6/site-packages/nose/importer.py line 47 in importFromPath
      return self.importFromDir(dir_path, fqname)
    .venv/contentpublisher-3.0.0-Linux/lib/python2.6/site-packages/nose/importer.py line 94 in importFromDir
      mod = load_module(part_fqname, fh, filename, desc)
    tests/**init**.py line 6 in <module>
      from contpublisher import requestmanager
    src/contpublisher/requestmanager.py line 32 in <module>
      from contpublisher import cdnmanager
    src/contpublisher/cdnmanager.py line 12 in <module>
      import ijson.backends.python as ijson
    .venv/contentpublisher-3.0.0-Linux/lib/python2.6/site-packages/ijson/**init**.py line 21 in <module>
      import ijson.backends.yajl2 as backend
    .venv/contentpublisher-3.0.0-Linux/lib/python2.6/site-packages/ijson/backends/yajl2.py line 14 in <module>
      yajl = backends.find_yajl(2)
    .venv/contentpublisher-3.0.0-Linux/lib/python2.6/site-packages/ijson/backends/**init**.py line 11 in find_yajl
      major, rest = divmod(yajl.yajl_version(), 10000)
    /usr/lib64/python2.6/ctypes/**init**.py line 366 in **getattr**
      func = self.**getitem**(name)
    /usr/lib64/python2.6/ctypes/**init**.py line 371 in **getitem**
      func = self._FuncPtr((name_or_ordinal, self))
   AttributeError: /usr/lib64/libyajl.so.1: undefined symbol: yajl_version
