### PR TITLE
bugfix in python.py

### DIFF
--- a/ijson/backends/python.py
+++ b/ijson/backends/python.py
@@ -124,7 +124,7 @@ def parse_value(lexer, symbol=None, pos=0):
                 number = decimal.Decimal(symbol)
                 int_number = int(number)
                 if int_number == number:
-                    number == int_number
+                    number = int_number
                 yield ('number', number)
             except decimal.InvalidOperation:
                 raise UnexpectedSymbol(symbol, pos)


### PR DESCRIPTION
== should be =
It actually might be better to use number._isinteger()
