### PR TITLE
import `ctypes` module on demand

### DIFF
--- a/ijson/backends/__init__.py
+++ b/ijson/backends/__init__.py
@@ -1,4 +1,3 @@
-from ctypes import util, cdll
 
 
 class YAJLImportError(ImportError):
@@ -10,6 +9,11 @@ def find_yajl(required):
     Finds and loads yajl shared object of the required major
     version (1, 2, ...).
     '''
+    # Importing ``ctypes`` should be in scope of this function to prevent failure
+    # of `backends`` package load in a runtime where ``ctypes`` is not available. 
+    # Example of such environment is Google App Engine (GAE). 
+    from ctypes import util, cdll
+
     so_name = util.find_library('yajl')
     if so_name is None:
         raise YAJLImportError('YAJL shared object not found.')


### PR DESCRIPTION
Google App Engine has a restricted python environment which doesn't allow to import `ctypes`.
This fact makes it impossible to specify usage of pure python backend implementation.