### PR TITLE
unescape map keys

### DIFF
--- a/ijson/backends/python.py
+++ b/ijson/backends/python.py
@@ -156,7 +156,7 @@ def parse_object(lexer):
             while True:
                 if symbol[0] != '"':
                     raise UnexpectedSymbol(symbol, pos)
-                yield ('map_key', symbol[1:-1])
+                yield ('map_key', unescape(symbol[1:-1]))
                 pos, symbol = next(lexer)
                 if symbol != ':':
                     raise UnexpectedSymbol(symbol, pos)


### PR DESCRIPTION
This test shows that the python backend does not unescape the keys of a dict. I assume it should. The pull request fixes this. BTW the yajl backend returns str instead of unicode keys, which is probably might be a problem on its own.

```
import StringIO
import sys

assert sys.argv[1] in ('c', 'p')
cBackend = sys.argv[1]=='c'
if cBackend:
    import ijson.backends.yajl as ijson
else:
    import ijson

js = '[ {"a\\/b": "c\\/d"} ]'
print js
f = StringIO.StringIO(js)
for d in ijson.items(f, 'item'):
    print d
```

Output:
```
> python test.py p
[ {"a\/b": "c\/d"} ]
{u'a\\/b': u'c/d'}

> python test.py c
[ {"a\/b": "c\/d"} ]
{'a/b': u'c/d'}
```