### PR TITLE
Handle piles of poo correctly

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -115,6 +115,7 @@ STRINGS_JSON = br'''
 }
 '''
 INT_NUMBERS_JSON = b'[1, 1.0, 1E2]'
+SURROGATE_PAIRS_JSON = b'"\uD83D\uDCA9"'
 
 
 class Parse(object):
@@ -181,6 +182,11 @@ class Parse(object):
         buf_size = JSON.index(b'   ') + 1
         events = list(self.backend.basic_parse(BytesIO(JSON), buf_size=buf_size))
         self.assertEqual(events, JSON_EVENTS)
+
+    def test_surrogate_pairs(self):
+        event = next(self.backend.basic_parse(BytesIO(SURROGATE_PAIRS_JSON)))
+        parsed_string = event[1]
+        self.assertEqual(parsed_string, '💩')
 
     def test_api(self):
         self.assertTrue(list(self.backend.items(BytesIO(JSON), '')))


### PR DESCRIPTION
Previously, this module failed to handle UTF-16 surrogate pairs correctly. Astral symbols in JSON are encoded using the two surrogate code points that UTF-16 would use, as described in https://tools.ietf.org/html/rfc7159#section-7, but this module had no awareness of this.

This PR contains two commits. The first adds a Pile Of Poo Test that demonstrates the bug, and the second fixes it by nuking `unescape` and instead deferring string parsing to Python's built-in JSON parser. Why create what we can steal?