### PR TITLE
Prevent memory leaks

### DIFF
--- a/ijson/common.py
+++ b/ijson/common.py
@@ -143,6 +143,7 @@ def items(prefixed_events, prefix):
                     while (current, event) != (prefix, end_event):
                         builder.event(event, value)
                         current, event, value = next(prefixed_events)
+                    del builder.containers[:]
                     yield builder.value
                 else:
                     yield value


### PR DESCRIPTION
The builder.containers list creates circular references between itself and the
ObjectBuilder object that contains it. This means that garbage collection is
taking care of disposing of these self-referencing objects from time to time.
If no GC is enabled (e.g., when using timeit.timeit, or because intentionally
turned off) these objects build up in memory, defeating the purpose of the
items generator and those under it. By explicitly clearing up the builder's
list before the builder gets out of scope we solve this.

To reproduce try:

``` python
import gc
import io
from ijson.backends import yajl2_cffi as ijson

stream = io.BytesIO(b'[' + b','.join( (b'{"a": "b", "c": 1, "d": [2,3,"4"]}',)*5000000 ) + b']')
gc.disable()
for _ in ijson.items(stream, "item"): pass
```

and see your memory usage grow.
